### PR TITLE
Add URLEncoder to mText parameter when building the API query string 

### DIFF
--- a/src/main/java/edu/usf/cutr/pelias/SearchRequest.java
+++ b/src/main/java/edu/usf/cutr/pelias/SearchRequest.java
@@ -56,7 +56,14 @@ public class SearchRequest {
          */
         public Builder(String apiKey, String text) {
             mApiKey = apiKey;
-            mText = text;
+
+            try {
+                mText = URLEncoder.encode(text, "UTF-8");
+            } catch (java.io.UnsupportedEncodingException e) {
+                   System.err.println( String.format("URLEncoder.encode failed (%s), using unencoded text parameter.", e.getMessage()) );
+                   mText = text;
+            }
+
         }
 
         /**
@@ -144,11 +151,11 @@ public class SearchRequest {
          * Builds the SearchRequest using the specified parameters
          * @return the SearchRequest using the specified parameters
          */
-        public SearchRequest build() throws java.io.UnsupportedEncodingException {
+        public SearchRequest build() {
             StringBuilder builder = new StringBuilder();
             builder.append(mApiEndPoint);
             builder.append("?text=");
-            builder.append( URLEncoder.encode(mText, "UTF-8") );
+            builder.append(mText);
             builder.append("&api_key=");
             builder.append(mApiKey);
 

--- a/src/main/java/edu/usf/cutr/pelias/SearchRequest.java
+++ b/src/main/java/edu/usf/cutr/pelias/SearchRequest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-
+import java.net.URLEncoder;
 
 /**
  * Encapsulates a request to the Mapzen Pelias Search API - https://mapzen.com/documentation/search/search/
@@ -144,11 +144,11 @@ public class SearchRequest {
          * Builds the SearchRequest using the specified parameters
          * @return the SearchRequest using the specified parameters
          */
-        public SearchRequest build() {
+        public SearchRequest build() throws java.io.UnsupportedEncodingException {
             StringBuilder builder = new StringBuilder();
             builder.append(mApiEndPoint);
             builder.append("?text=");
-            builder.append(mText);
+            builder.append( URLEncoder.encode(mText, "UTF-8") );
             builder.append("&api_key=");
             builder.append(mApiKey);
 

--- a/src/test/java/edu/usf/cutr/pelias/SearchTest.java
+++ b/src/test/java/edu/usf/cutr/pelias/SearchTest.java
@@ -193,5 +193,21 @@ public class SearchTest extends TestCase {
                         "&boundary.rect.min_lat=27.959868&boundary.rect.min_lon=-82.515286" +
                         "&boundary.rect.max_lat=28.131471&boundary.rect.max_lon=-82.367646",
                 request.getUrl().toString());
+
+        request = new SearchRequest.Builder(API_KEY, "burger king")
+                .setApiEndpoint(SEARCH_WITH_FOCUS_ENDPOINT)
+                .setFocusPoint(28.061062d, -82.4132d)
+                .setSources("osm")
+                .setSize(35)
+                .setBoundaryRect(27.959868, -82.515286, 28.131471, -82.367646)
+                .build();
+
+        assertEquals("https://raw.githubusercontent.com/CUTR-at-USF/pelias-client-library/master/src/test/resources/" +
+                        "search-with-focus.json?text=burger+king&api_key=dummyApiKey&sources=osm&size=35" +
+                        "&focus.point.lat=28.061062&focus.point.lon=-82.4132" +
+                        "&boundary.rect.min_lat=27.959868&boundary.rect.min_lon=-82.515286" +
+                        "&boundary.rect.max_lat=28.131471&boundary.rect.max_lon=-82.367646",
+                request.getUrl().toString());
+        
     }
 }


### PR DESCRIPTION
This fixes an issue where spaces (and other characters) would break the query.

An alternative (possibly overkill) approach is to use a URIBuilder instead of StringBuilder.

None of the tests failed with this patch, and my local testing yields local results for "burger+k" instead of results outside of the US like it does now.

I did not add any Javadocs RE: the `@throws` for URLEncoder, and there were 2 other warnings about that when I compiled:

```
3 warnings
[WARNING] Javadoc Warnings
[WARNING] /home/icmp/pelias-client-library/src/main/java/edu/usf/cutr/pelias/SearchRequest.java:207: warning: no description for @throws
[WARNING] * @throws IOException
[WARNING] ^
[WARNING] /home/icmp/pelias-client-library/src/main/java/edu/usf/cutr/pelias/SearchRequest.java:229: warning: no description for @param
[WARNING] * @param args
[WARNING] ^
[WARNING] /home/icmp/pelias-client-library/src/main/java/edu/usf/cutr/pelias/SearchRequest.java:147: warning: no @throws for java.io.UnsupportedEncodingException
[WARNING] public SearchRequest build() throws java.io.UnsupportedEncodingException {
```
